### PR TITLE
Add support for diffing files

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,6 +3,7 @@ import json
 from time import sleep
 import typing as tp
 import tempfile
+from pathlib import Path
 
 import cudatext as ct
 import cudatext_cmd as ct_cmd
@@ -14,6 +15,7 @@ from .ui import DifferDialog, file_history
 
 from cudax_lib import get_translation
 _ = get_translation(__file__)  # I18N
+
 
 DIFF_TAG = 148
 NKIND_DELETED = 24
@@ -28,6 +30,7 @@ PLG_NAME = 'Differ'
 METAJSONFILE = os.path.dirname(__file__) + os.sep + 'differ_opts.json'
 JSONFILE = 'cuda_differ.json'  # To store in settings/cuda_differ.json
 JSONPATH = ct.app_path(ct.APP_DIR_SETTINGS) + os.sep + JSONFILE
+
 OPTS_META = [
     {'opt': 'differ.changed_color',
      'cmt': _('Color of changed lines'),
@@ -83,11 +86,19 @@ OPTS_META = [
      'frm': 'bool',
      'chp': 'config',
      },
+     {'opt': 'differ.diff_context',
+     'cmt': _('Number of lines of context displayed when diffing files'),
+     'def':  3,
+     'frm': 'int',
+     'chp': 'config',
+     },
 ]
-
 
 TEMP_DIR = os.path.join(tempfile.gettempdir(), 'cuda_differ')
 TEMP_INDEX = 0
+
+DIFF_TAB_COUNT = 1
+
 
 def get_temp_name():
     global TEMP_DIR
@@ -196,8 +207,42 @@ class Command:
         name = names[res]
         self.set_files(name0, name)
 
-    def format_untitled(self, e):
+    def diff_with(self):
+        fn0 = self.get_name(ct.ed)
+        fn = ct.dlg_file(True, '!', '', '')
+        if not fn:
+            return
 
+        enc = ct.ed.get_prop(ct.PROP_ENC)
+        a = ct.ed.get_text_all()
+        b = Path(fn).read_text(enc)
+        self.create_diff(a, b, fn0, fn)
+
+    def diff_with_tab(self):
+        name0 = self.get_name(ct.ed)
+
+        names = []
+        ed = []
+        for h in ct.ed_handles():
+            e = ct.Editor(h)
+            if self.is_match_name(e, name0):
+                continue
+            names.append(self.get_name(e))
+            ed.append(h)
+        if not names:
+            return
+
+        res = ct.dlg_menu(ct.DMENU_LIST, names, caption=_('Diff file with tab'))
+        if res is None:
+            return
+
+        name = names[res]
+        a = ct.ed.get_text_all()
+        b = ct.Editor(ed[res]).get_text_all()
+
+        self.create_diff(a, b, name0, name)
+
+    def format_untitled(self, e):
         return U_PREFIX + e.get_prop(ct.PROP_TAB_TITLE) + ' [%d]'%e.get_prop(ct.PROP_TAB_ID)
 
     def is_match_name(self, e, name):
@@ -243,6 +288,23 @@ class Command:
                 ct.app_proc(ct.PROC_SET_GROUPING, ct.GROUPS_ONE)
 
         self.refresh()
+
+    def create_diff(self, txt0, txt1, fn0, fn1):
+        a = txt0.splitlines(True)
+        b = txt1.splitlines(True)
+        r = self.diff.unidiff(a, b, fn0, fn1, self.cfg.get('diff_context'))
+
+        global DIFF_TAB_COUNT
+        tab = 'Diff ' + str(DIFF_TAB_COUNT)
+        DIFF_TAB_COUNT += 1
+
+        ct.file_open('')
+        ct.ed.set_text_all(r)
+        ct.ed.set_prop(ct.PROP_LEXER_FILE, 'Diff')
+        ct.ed.set_prop(ct.PROP_RO, True)
+        ct.ed.set_prop(ct.PROP_TAB_TITLE, tab)
+        ct.ed.set_prop(ct.PROP_TAB_TITLE_REASON, 'p')
+        ct.ed.set_prop(ct.PROP_SAVE_HISTORY, False)
 
     def on_state(self, ed_self, state):
         if state == ct.APPSTATE_THEME_SYNTAX:
@@ -447,6 +509,8 @@ class Command:
                 get_opt('enable_sync_caret', False),
             'enable_auto_refresh':
                 get_opt('enable_auto_refresh', False),
+            'diff_context':
+                get_opt('diff_context', 3),
         }
 
         new_nkind(NKIND_DELETED, config.get('color_deleted'))
@@ -485,7 +549,7 @@ class Command:
             p = 2 if to_next else 3
         y = eds[fc].get_carets()[0][1]
         line_cnt = eds[fc].get_line_count()
-        
+
         if to_next:
             for n, df in enumerate(self.diff.diffmap):
                 df_y = df[p] if df[p] <= line_cnt - 1 else line_cnt - 1

--- a/__init__.py
+++ b/__init__.py
@@ -290,6 +290,8 @@ class Command:
         self.refresh()
 
     def create_diff(self, txt0, txt1, fn0, fn1):
+        if txt0[-1] != '\n': txt0 += '\n'
+        if txt1[-1] != '\n': txt1 += '\n'
         a = txt0.splitlines(True)
         b = txt1.splitlines(True)
         r = self.diff.unidiff(a, b, fn0, fn1, self.cfg.get('diff_context'))

--- a/differ.py
+++ b/differ.py
@@ -1,4 +1,4 @@
-from difflib import SequenceMatcher
+from difflib import SequenceMatcher, unified_diff
 
 
 A_LINE_DEL = '-'
@@ -72,6 +72,10 @@ class Differ:
                     for y in range(j1, j2):
                         yield (B_LINE_CHANGE, y)
                         yield (B_DECOR_YELLOW, y)
+
+    def unidiff(self, a, b, f1, f2, n):
+        print('n='+str(n)) # always prints 3 :-(
+        return ''.join(unified_diff(a, b, f1, f2, n=n))
 
     def _fancy_replace(self, a, alo, ahi, b, blo, bhi):
         best_ratio, cutoff = self.ratio-0.01, self.ratio

--- a/install.inf
+++ b/install.inf
@@ -23,20 +23,30 @@ method=compare_with_tab
 
 [item3]
 section=commands
+caption=Differ\Diff current document with file...
+method=diff_with
+
+[item3b]
+section=commands
+caption=Differ\Diff current document with tab...
+method=diff_with_tab
+
+[item4]
+section=commands
 caption=Differ\Refresh
 method=refresh
 
-[item4]
+[item5]
 section=commands
 caption=Differ\Focus the opposite file
 method=set_focus_to_opposite_panel
 
-[item5]
+[item6]
 section=commands
 caption=Differ\Select current difference
 method=select_current
 
-[item6]
+[item7]
 section=commands
 caption=Differ\Select all differences
 method=select_all_diff

--- a/readme/history.txt
+++ b/readme/history.txt
@@ -1,3 +1,6 @@
+2023.01.18
++ add: commands to produce a diff file (or patch)
+
 2022.12.28
 + add: support different untitled tabs which have the same tab-title
 

--- a/readme/readme.txt
+++ b/readme/readme.txt
@@ -3,16 +3,18 @@ It compares two files and shows them side-by-side.
 Plugin shows two files in a single tab.
 
 It gives few commands in menu "Plugins / Differ".
-Command "Refresh" runs comparision again, if one or both files were edited.
+Command "Refresh" runs comparison again, if one or both files were edited.
 It has options dialog, call it via "Options / Settings-plugins / Differ / Config".
 
 Plugin supports CudaText running with "-p" command-line param:
   cudatext -p=cuda_differ#filename1#filename2
 This will run CudaText with 2 given filenames in the Differ plugin.
 
+The plugin can also produce a diff file (or patch).
 
 Authors:
   OlehL, https://github.com/OlehL
   Alexey Torgashin (CudaText)
   Andrey Kvichanskiy, https://github.com/kvichans
+  Vivalzar, https://github.com/Vivalzar
 License: MIT


### PR DESCRIPTION
I updated this plugin to add support for diffing files (like in ST). It produces that kind of files:
```diff
--- before.py
+++ after.py
@@ -1,4 +1,4 @@
-bacon
-eggs
-ham
+python
+eggy
+hamster
 guido
```

Feel free to try it and to give me some tips: it's my first contribution.

I already know that the new option I added (`diff_context`) doesn't work. It always uses the default value. It would be nice of you if you could help me on that.